### PR TITLE
Fix parse failures when parsing semantically empty objects and arrays

### DIFF
--- a/src/Data/JSON/QQ.hs
+++ b/src/Data/JSON/QQ.hs
@@ -80,7 +80,7 @@ jpNumber = JsonNumber <$> do
 
 jpObject :: JsonParser
 jpObject = do
-  list <- between (char '{') (char '}') (commaSep jpHash)
+  list <- between (char '{') (char '}') (spaces *> commaSep jpHash)
   return $ JsonObject $ list
   where
     jpHash :: CharParser () (HashKey,JsonValue) -- (String,JsonValue)
@@ -104,7 +104,7 @@ varKey :: CharParser () HashKey
 varKey = HashVarKey <$> (char '$' *> symbol)
 
 jpArray :: CharParser () JsonValue
-jpArray = JsonArray <$> between (char '[') (char ']') (commaSep jpValue)
+jpArray = JsonArray <$> between (char '[') (char ']') (spaces *> commaSep jpValue)
 
 -------
 -- helpers for parser/grammar

--- a/test/Data/JSON/QQSpec.hs
+++ b/test/Data/JSON/QQSpec.hs
@@ -19,9 +19,31 @@ spec = do
       let Right value = parsedJson "{foo: 5.97}"
       value `shouldBe` JsonObject [(HashStringKey "foo", JsonNumber 5.97)]
 
-    it "parses empty objects (regression test)" $ do
-      let Right value = parsedJson "{}"
-      value `shouldBe` JsonObject []
+    context "empty objects" $ do
+      it "parses empty objects (regression test)" $ do
+        let Right value = parsedJson "{}"
+        value `shouldBe` JsonObject []
+
+      it "parses empty objects that include whitespace (regression test)" $ do
+        let Right value = parsedJson "{ }"
+        value `shouldBe` JsonObject []
+
+      it "parses empty objects that include newlines (regression test)" $ do
+        let Right value = parsedJson "{\n}"
+        value `shouldBe` JsonObject []
+
+    context "empty arrays" $ do
+      it "parses empty arrays" $ do
+        let Right value = parsedJson "[   ]"
+        value `shouldBe` JsonArray []
+
+      it "parses empty arrays that include whitespace (regression test)" $ do
+        let Right value = parsedJson "[   ]"
+        value `shouldBe` JsonArray []
+
+      it "parses empty objects that include newlines (regression test)" $ do
+        let Right value = parsedJson "[\n]"
+        value `shouldBe` JsonArray []
 
     it "fails on excess input" $ do
       let Left err = parsedJson "{foo: 23} some excess input"


### PR DESCRIPTION
The fix is to eat all of the spaces before the object and array parsers
attempt to parse the non-existent contents.